### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::git::home::symlink()`
 - `p6df::modules::git::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::git::prompt::init()`
 - `p6df::modules::git::prompt::mod()`
 - `p6df::modules::git::prompt_precmd()`

--- a/init.zsh
+++ b/init.zsh
@@ -65,8 +65,8 @@ p6df::modules::git::external::brew() {
 ######################################################################
 p6df::modules::git::home::symlink() {
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitconfig" ".gitconfig"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitignore_global" ".gitignore_global"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitconfig" "$HOME/.gitconfig"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitignore_global" "$HOME/.gitignore_global"
 
   p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.