### PR TITLE
chore: replace git lfs install with p6_git_cli lfs install

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -51,7 +51,7 @@ p6df::modules::git::external::brew() {
   p6df::core::homebrew::cli::brew::install tig
   p6_file_copy "$HOMEBREW_PREFIX"/opt/tig/share/tig/examples/tigrc "$HOMEBREW_PREFIX"/etc/tigrc
 
-  git lfs install
+  p6_git_cli lfs install
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Replace raw `git lfs install` with `p6_git_cli lfs install` in `init.zsh:54`

## Test plan

- [ ] `p6df::modules::git::external::brew` installs git-lfs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)