### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -34,12 +34,12 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::git::external::brew()
+# Function: p6df::modules::git::external::brews()
 #
 #  Environment:	 HOMEBREW_PREFIX
 #>
 ######################################################################
-p6df::modules::git::external::brew() {
+p6df::modules::git::external::brews() {
 
   p6df::core::homebrew::cli::brew::install git
   p6df::core::homebrew::cli::brew::install git-delta


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly