### PR TITLE
chore(git): rename home::symlink to home::symlinks

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -59,12 +59,12 @@ p6df::modules::git::external::brews() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::git::home::symlink()
+# Function: p6df::modules::git::home::symlinks()
 #
 #  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::git::home::symlink() {
+p6df::modules::git::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitconfig" "$HOME/.gitconfig"
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitignore_global" "$HOME/.gitignore_global"


### PR DESCRIPTION
## What
Rename `home::symlink` (singular) to `home::symlinks` (plural).

## Why
The p6df-core framework dispatches `home::symlinks` (plural) via `p6df::core::internal::recurse`. The singular function was never auto-called — ~/.gitconfig and ~/.gitignore_global symlinks only existed from prior manual creation.

## Test plan
- `p6df home symlinks` now recreates ~/.gitconfig and ~/.gitignore_global

## Dependencies
None