### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::git::deps()
+#
+#>
+######################################################################
 p6df::modules::git::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-zsh
@@ -8,6 +14,12 @@ p6df::modules::git::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::git::aliases::init()
+#
+#>
 ######################################################################
 p6df::modules::git::aliases::init() {
 
@@ -56,6 +68,12 @@ p6df::modules::git::aliases::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::git::prompt::init()
+#
+#>
+######################################################################
 p6df::modules::git::prompt::init() {
 
   local _module="$1"
@@ -63,6 +81,13 @@ p6df::modules::git::prompt::init() {
   add-zsh-hook precmd p6df::modules::git::prompt_precmd
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::git::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
 ######################################################################
 p6df::modules::git::home::symlinks() {
 
@@ -72,6 +97,13 @@ p6df::modules::git::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::git::external::brews()
+#
+#  Environment:	 HOMEBREW_PREFIX
+#>
 ######################################################################
 p6df::modules::git::external::brews() {
 
@@ -91,6 +123,12 @@ p6df::modules::git::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::git::vscodes::config()
+#
+#>
+######################################################################
 p6df::modules::git::vscodes::config() {
 
   cat <<'EOF'
@@ -101,44 +139,6 @@ EOF
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::git::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::git::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::git::external::brews()
-#
-#  Environment:	 HOMEBREW_PREFIX
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::git::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::git::aliases::init()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::git::prompt::init()
-#
-#>
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::git::deps()
-#
-#>
-######################################################################
 p6df::modules::git::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-zsh
@@ -14,70 +8,6 @@ p6df::modules::git::deps() {
   )
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::git::vscodes::config()
-#
-#>
-######################################################################
-p6df::modules::git::vscodes::config() {
-
-  cat <<'EOF'
-  "git.openRepositoryInParentFolders": "never",
-  "gitlens.graph.layout": "editor"
-EOF
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::git::external::brews()
-#
-#  Environment:	 HOMEBREW_PREFIX
-#>
-######################################################################
-p6df::modules::git::external::brews() {
-
-  p6df::core::homebrew::cli::brew::install git
-  p6df::core::homebrew::cli::brew::install git-delta
-  p6df::core::homebrew::cli::brew::install git-extras
-  p6df::core::homebrew::cli::brew::install git-lfs
-  p6df::core::homebrew::cli::brew::install git-quick-stats
-  p6df::core::homebrew::cli::brew::install git-secret
-
-  p6df::core::homebrew::cli::brew::install tig
-  p6_file_copy "$HOMEBREW_PREFIX"/opt/tig/share/tig/examples/tigrc "$HOMEBREW_PREFIX"/etc/tigrc
-
-  p6_git_cli lfs install
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::git::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::git::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitconfig" "$HOME/.gitconfig"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitignore_global" "$HOME/.gitignore_global"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::git::aliases::init()
-#
-#>
 ######################################################################
 p6df::modules::git::aliases::init() {
 
@@ -126,12 +56,6 @@ p6df::modules::git::aliases::init() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::git::prompt::init()
-#
-#>
-######################################################################
 p6df::modules::git::prompt::init() {
 
   local _module="$1"
@@ -139,6 +63,82 @@ p6df::modules::git::prompt::init() {
   add-zsh-hook precmd p6df::modules::git::prompt_precmd
 }
 
+######################################################################
+p6df::modules::git::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitconfig" "$HOME/.gitconfig"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-git/share/.gitignore_global" "$HOME/.gitignore_global"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::git::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install git
+  p6df::core::homebrew::cli::brew::install git-delta
+  p6df::core::homebrew::cli::brew::install git-extras
+  p6df::core::homebrew::cli::brew::install git-lfs
+  p6df::core::homebrew::cli::brew::install git-quick-stats
+  p6df::core::homebrew::cli::brew::install git-secret
+
+  p6df::core::homebrew::cli::brew::install tig
+  p6_file_copy "$HOMEBREW_PREFIX"/opt/tig/share/tig/examples/tigrc "$HOMEBREW_PREFIX"/etc/tigrc
+
+  p6_git_cli lfs install
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::git::vscodes::config() {
+
+  cat <<'EOF'
+  "git.openRepositoryInParentFolders": "never",
+  "gitlens.graph.layout": "editor"
+EOF
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::git::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::git::vscodes::config()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::git::external::brews()
+#
+#  Environment:	 HOMEBREW_PREFIX
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::git::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::git::aliases::init()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::git::prompt::init()
+#
+#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None